### PR TITLE
JWT schema

### DIFF
--- a/backend/schemas/JWTSchema.go
+++ b/backend/schemas/JWTSchema.go
@@ -1,5 +1,5 @@
 package schemas
 
 type JWT struct {
-	Token string `json:"token"`
+	Token string `json:"access_token"`
 }


### PR DESCRIPTION
This pull request includes a small change to the `backend/schemas/JWTSchema.go` file. The change updates the JSON key for the `Token` field from `token` to `access_token`.

* [`backend/schemas/JWTSchema.go`](diffhunk://#diff-7030e0c4d5d8f41447fcd4364148b673422de7a3e0c91d61f37644a99566ba25L4-R4): Changed the JSON key for the `Token` field from `token` to `access_token`.