### PR TITLE
[FIX] github OAuth2 login / register

### DIFF
--- a/backend/controllers/githubController.go
+++ b/backend/controllers/githubController.go
@@ -91,7 +91,9 @@ func (controller *githubController) ServiceGithubCallback(ctx *gin.Context, path
 			isAlreadyRegistered = true
 		}
 	}
-	actualUser = controller.userService.GetUserByEmail(userInfo.Email)
+	if userInfo.Email != "" {
+		actualUser = controller.userService.GetUserByEmail(userInfo.Email)
+	}
 	if actualUser.Email != "" {
 		isAlreadyRegistered = true
 	}
@@ -112,9 +114,10 @@ func (controller *githubController) ServiceGithubCallback(ctx *gin.Context, path
 		if err != nil {
 			return "", fmt.Errorf("unable to create user because %w", err)
 		}
-		actualUser = controller.userService.GetUserByEmail(userInfo.Email)
+		actualUser = controller.userService.GetUserByUsername(userInfo.Login)
 		newGithubToken = schemas.ServiceToken{
 			Token:   githubTokenResponse.AccessToken,
+			RefreshToken: githubTokenResponse.RefreshToken,
 			Service: githubService,
 			UserId:  actualUser.Id,
 		}

--- a/backend/schemas/githubSchema.go
+++ b/backend/schemas/githubSchema.go
@@ -13,9 +13,10 @@ const (
 )
 
 type GitHubResponseToken struct {
-	AccessToken string `json:"access_token"`
-	Scope       string `json:"scope"`
-	TokenType   string `json:"token_type"`
+	AccessToken 	string `json:"access_token"`
+	RefreshToken 	string `json:"refresh_token"`
+	Scope       	string `json:"scope"`
+	TokenType   	string `json:"token_type"`
 }
 
 type GithubUserInfo struct {

--- a/backend/services/githubService.go
+++ b/backend/services/githubService.go
@@ -59,14 +59,12 @@ func (service *githubService) AuthGetServiceAccessToken(code string, path string
 	if err != nil {
 		return schemas.GitHubResponseToken{}, err
 	}
-	fmt.Printf("response body: %v\n", response.Body)
 	var resultToken schemas.GitHubResponseToken
 	err = json.NewDecoder(response.Body).Decode(&resultToken)
 	if err != nil {
 		return schemas.GitHubResponseToken{}, err
 	}
 	response.Body.Close()
-	fmt.Printf("resultToken: %v\n", resultToken)
 	return resultToken, nil
 }
 
@@ -75,7 +73,6 @@ func (service *githubService) GetUserInfo(accessToken string) (schemas.GithubUse
 	if err != nil {
 		return schemas.GithubUserInfo{}, err
 	}
-	fmt.Printf("accessToken: %s\n", accessToken)
 	request.Header.Set("Authorization", "Bearer "+accessToken)
 	client := &http.Client{}
 	response, err := client.Do(request)


### PR DESCRIPTION
This pull request includes several changes to the GitHub authentication and user retrieval functionality in the backend. The most important changes involve adding support for refresh tokens, modifying how user information is retrieved, and removing debug print statements.

Enhancements to GitHub authentication:

* [`backend/schemas/githubSchema.go`](diffhunk://#diff-8bfd9d753fff2fc6828e54fd84baae0eb55407ca8fae19f421391c33dd296e73R17): Added a `RefreshToken` field to the `GitHubResponseToken` struct to support refresh tokens.
* [`backend/controllers/githubController.go`](diffhunk://#diff-a3aefe88d1049ebeb2bb7732f217e6cdc770256766fa0ea855385780ffecb277L115-R120): Updated the `ServiceGithubCallback` method to include the `RefreshToken` when creating a new GitHub token.

User retrieval improvements:

* [`backend/controllers/githubController.go`](diffhunk://#diff-a3aefe88d1049ebeb2bb7732f217e6cdc770256766fa0ea855385780ffecb277L115-R120): Modified the `ServiceGithubCallback` method to retrieve the user by username instead of email when creating a new user.
* [`backend/controllers/githubController.go`](diffhunk://#diff-a3aefe88d1049ebeb2bb7732f217e6cdc770256766fa0ea855385780ffecb277R94-R96): Added a condition to check if the `Email` field in `userInfo` is not empty before attempting to get the user by email.

Code cleanup:

* [`backend/services/githubService.go`](diffhunk://#diff-ea08924425ea28ae01e98c3ee7955b64f9f48cb6ed8084b1297f14831e6149adL62-L69): Removed debug print statements from the `AuthGetServiceAccessToken` and `GetUserInfo` methods. [[1]](diffhunk://#diff-ea08924425ea28ae01e98c3ee7955b64f9f48cb6ed8084b1297f14831e6149adL62-L69) [[2]](diffhunk://#diff-ea08924425ea28ae01e98c3ee7955b64f9f48cb6ed8084b1297f14831e6149adL78)

Closes #114