### PR TITLE
[UPD] put fetch that need auth token in endpoints

### DIFF
--- a/frontend/pages/callback.vue
+++ b/frontend/pages/callback.vue
@@ -18,7 +18,7 @@ async function fetchGitHubToken() {
   if (code && state) {
     try {
       const response = await Promise.race([
-        $fetch<ApiResponse>("/api/callback", {
+        $fetch<ApiResponse>("/api/auth/callback", {
           method: "POST",
           body: {
             code: code as string,

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -15,7 +15,7 @@ async function onSubmit() {
     });
 
     if (access_token) {
-      const tokenCookie = useCookie("token");
+      const tokenCookie = useCookie("access_token");
       tokenCookie.value = access_token;
 
       navigateTo("/services");

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -7,16 +7,20 @@ const password = ref("");
 
 async function onSubmit() {
   try {
-    const { access_token } = await $fetch("http://localhost:8080/api/auth/register", {
-      method: "POST",
-      body: {
-        username: username.value,
-        email: email.value,
-        password: password.value,
-      },
-    });
+    const { access_token } = await $fetch(
+      "http://localhost:8080/api/auth/register",
+      {
+        method: "POST",
+        body: {
+          username: username.value,
+          email: email.value,
+          password: password.value,
+        },
+      }
+    );
     if (access_token) {
-      localStorage.setItem("access_token", access_token);
+      const tokenCookie = useCookie("access_token");
+      tokenCookie.value = access_token;
       navigateTo("/services");
     }
   } catch (error) {

--- a/frontend/pages/services.vue
+++ b/frontend/pages/services.vue
@@ -87,7 +87,7 @@ async function fetchServices() {
 }
 async function addWorkflow() {
   try {
-    await $fetch<ServerResponse>("/api/workflows", {
+    await $fetch<ServerResponse>("/api/workflows/addWorkflows", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token.value}`,
@@ -107,7 +107,7 @@ async function addWorkflow() {
 async function getLastWorkflow() {
   try {
     const response = await $fetch<WorkflowResponse[]>(
-      "http://localhost:8080/api/workflow/reaction",
+      "/api/workflows/getLastWorkflow",
       {
         method: "GET",
         headers: {

--- a/frontend/server/api/auth/callback.ts
+++ b/frontend/server/api/auth/callback.ts
@@ -3,7 +3,7 @@ export default defineEventHandler(async (event) => {
   if (!params.code || !params.state) {
     throw createError({
       statusCode: 400,
-      message: "Missing parameters: code, or service",
+      message: "Missing parameters: code, or state",
     });
   }
 

--- a/frontend/server/api/workflows/addWorkflows.ts
+++ b/frontend/server/api/workflows/addWorkflows.ts
@@ -5,7 +5,7 @@ export default defineEventHandler(async (event) => {
     if (!access_token || !params.action_id || !params.reaction_id) {
       throw createError({
         statusCode: 400,
-        message: "Missing parameters: code, or service",
+        message: "Missing parameters: token, action_id, or reaction_id",
       });
     }
     const response = await $fetch("http://server:8080/api/workflow", {

--- a/frontend/server/api/workflows/getLastWorkflow.ts
+++ b/frontend/server/api/workflows/getLastWorkflow.ts
@@ -1,0 +1,23 @@
+export default defineEventHandler(async (event) => {
+    const access_token = event.headers.get("Authorization");
+    const contentTypes = event.headers.get("Content-Type");
+    if (!access_token || !contentTypes) {
+        throw createError({
+            statusCode: 400,
+            message: "Missing parameters: token or content type",
+        });
+    }
+    try {
+        const response = await $fetch("http://server:8080/api/workflow/reaction", {
+            method: "GET",
+            headers: {
+                Authorization: access_token ? `${access_token}` : "",
+                "Content-Type": contentTypes ? `${contentTypes}` : "",
+            },
+        });
+        return response;
+    } catch (error) {
+        console.error("Error in API server:", error);
+        return { statusCode: 500, message: "Failed to get last workflow" };
+    }
+});


### PR DESCRIPTION
This pull request includes several updates to the authentication and workflows API endpoints, along with some refactoring and bug fixes in the frontend code. The most important changes are listed below:

### Authentication Updates:

* [`frontend/pages/callback.vue`](diffhunk://#diff-712bd61c876ebb0e3a1c9911983f19d0ddba42f83749e521b6a1cbeca26b343aL21-R21): Updated the API endpoint for fetching the GitHub token to use the correct path `/api/auth/callback`.
* [`frontend/pages/login.vue`](diffhunk://#diff-0070bd6cc2d3419e72bc4f6f4e0db3c1fc1df27af1b7774ec53a2129515dc070L18-R18): Changed the cookie name from `token` to `access_token` to maintain consistency across the application.
* [`frontend/pages/register.vue`](diffhunk://#diff-495f9362778e96f048daee3430a72105833fad5c4d238482d67645cf88e234b3L10-R23): Updated the registration API call and changed the storage method for the access token from `localStorage` to a cookie named `access_token`.

### Workflow API Updates:

* [`frontend/pages/services.vue`](diffhunk://#diff-20f1b3a734f9ed54bf262ae4a659ad35992436c4011d135013be6e5b85437407L90-R90): Modified the API endpoints for adding and fetching workflows to use more descriptive paths `/api/workflows/addWorkflows` and `/api/workflows/getLastWorkflow`. [[1]](diffhunk://#diff-20f1b3a734f9ed54bf262ae4a659ad35992436c4011d135013be6e5b85437407L90-R90) [[2]](diffhunk://#diff-20f1b3a734f9ed54bf262ae4a659ad35992436c4011d135013be6e5b85437407L110-R110)
* [`frontend/server/api/workflows/getLastWorkflow.ts`](diffhunk://#diff-930b15f9c6d2b08de7eb8031b8a4fa24630f7cdea03831e788d04f722f2092e3R1-R23): Added a new handler for fetching the last workflow, including proper error handling and logging.

### Refactoring and Bug Fixes:

* [`frontend/server/api/auth/callback.ts`](diffhunk://#diff-a1b1ed123283d75d6e31ed41f27588ee832691d1428f770cf5fecb063721fe32L6-R6): Corrected the error message to reference the correct missing parameter `state`.
* [`frontend/server/api/workflows/addWorkflows.ts`](diffhunk://#diff-2c55fdbe3545055bdad5bfa4535ee1dbbc31a464e5f9efdf95d27a1d0bd06772L8-R8): Updated the error message to correctly list the missing parameters `token, action_id, or reaction_id`.