### PR TITLE
[ADD] google calendar reaction

### DIFF
--- a/backend/schemas/googleSchema.go
+++ b/backend/schemas/googleSchema.go
@@ -42,8 +42,31 @@ type GoogleActionOptionsInfo struct {
 	ResultSizeEstimate int `json:"resultSizeEstimate"`
 }
 
+type GoogleCalendarCorpusOptionsTime struct {
+	DateTime string `json:"dateTime"`
+	TimeZone string `json:"timeZone"`
+}
+
+type GoogleCalendarCorpusOptionsAttendees struct {
+	Email string `json:"email"`
+}
+
+type GoogleCalendarCorpusOptions struct {
+	Summary     string                               `json:"summary"`
+	Description string                               `json:"description"`
+	Location    string                               `json:"location"`
+	Start       GoogleCalendarCorpusOptionsTime      `json:"start"`
+	End         GoogleCalendarCorpusOptionsTime      `json:"end"`
+	Attendees   GoogleCalendarCorpusOptionsAttendees `json:"attendees"`
+}
+
+type GoogleCalendarOptions struct {
+	CalendarId     string                      `json:"calendar_id"`
+	CalendarCorpus GoogleCalendarCorpusOptions `json:"calendar_corpus"`
+}
+
 type GoogleCalendarResponse struct {
-	Items struct {
+	Items []struct {
 		Id string `json:"id"`
 	} `json:"items"`
 }

--- a/backend/services/reactionService.go
+++ b/backend/services/reactionService.go
@@ -54,12 +54,31 @@ func NewReactionService(
 				Name:        string(schemas.GoogleCreateEventReaction),
 				Description: "Create an event in Google Calendar",
 				ServiceId:   serviceService.FindByName(schemas.Google).Id,
+				Options: toolbox.MustMarshal(schemas.GoogleCalendarOptions{
+					CalendarId: "string",
+					CalendarCorpus: schemas.GoogleCalendarCorpusOptions{
+						Summary:     "string",
+						Description: "string",
+						Location:    "string",
+						Start: schemas.GoogleCalendarCorpusOptionsTime{
+							DateTime: "string",
+							TimeZone: "string",
+						},
+						End: schemas.GoogleCalendarCorpusOptionsTime{
+							DateTime: "string",
+							TimeZone: "string",
+						},
+						Attendees: schemas.GoogleCalendarCorpusOptionsAttendees{
+							Email: "string",
+						},
+					},
+				}),
 			},
 			{
 				Name:        "get_red_notices",
 				Description: "Detect a change on a specific notice",
 				ServiceId:   serviceService.FindByName(schemas.Interpol).Id,
-				Options:     toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
+				Options: toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
 					FirstName: "string",
 					LastName:  "string",
 				}),
@@ -68,7 +87,7 @@ func NewReactionService(
 				Name:        "get_yellow_notices",
 				Description: "Detect a change on a specific notice",
 				ServiceId:   serviceService.FindByName(schemas.Interpol).Id,
-				Options:     toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
+				Options: toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
 					FirstName: "string",
 					LastName:  "string",
 				}),
@@ -77,7 +96,7 @@ func NewReactionService(
 				Name:        "get_un_notices",
 				Description: "Detect a change on a specific notice",
 				ServiceId:   serviceService.FindByName(schemas.Interpol).Id,
-				Options:     toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
+				Options: toolbox.MustMarshal(schemas.InterpolReactionOptionInfos{
 					FirstName: "string",
 					LastName:  "string",
 				}),


### PR DESCRIPTION
This pull request includes several changes to the Google Calendar integration within the backend services. The changes focus on adding new data structures, enhancing the `CreateEventReaction` function, and updating the reaction service initialization.

### New Data Structures:
* Added `GoogleCalendarCorpusOptionsTime`, `GoogleCalendarCorpusOptionsAttendees`, `GoogleCalendarCorpusOptions`, and `GoogleCalendarOptions` structs in `backend/schemas/googleSchema.go` to encapsulate calendar event details.

### Enhancements to `CreateEventReaction` Function:
* Introduced the `workflow` variable to retrieve workflow details.
* Added logic to decode `reactionOption` into `GoogleCalendarOptions` and print the decoded options.
* Implemented functionality to find the desired calendar ID and create a new event using the Google Calendar API.

### Updates to Reaction Service Initialization:
* Updated the `NewReactionService` function to include `GoogleCalendarOptions` with nested structures for event details.

### Minor Changes:
* Added the `bytes` package import in `backend/services/googleService.go`.

This pull request Close #86 