### PR TITLE
HOT FIX - change the deletion of the workflow

### DIFF
--- a/backend/services/workflowService.go
+++ b/backend/services/workflowService.go
@@ -278,10 +278,21 @@ func (service *workflowService) DeleteWorkflow(ctx *gin.Context) error {
 			}
 			actualAction := service.actionService.FindById(wf.ActionId)
 			actualService := service.servicesService.FindById(actualAction.ServiceId)
-			if string(actualService.Name) == string(schemas.Google) {
+			switch string(actualService.Name) {
+			case string(schemas.Google):
 				actualGoogleAction := service.googleRepository.FindByWorkflowId(wf.Id)
 				service.googleRepository.Delete(actualGoogleAction)
+			case string(schemas.Github):
+				actualGithubAction := service.reactionResponseDataService.FindByWorkflowId(wf.Id)
+				for _, data := range actualGithubAction {
+					service.reactionResponseDataService.Delete(data)
+				}
+				// service.reactionResponseDataService.Delete(actualGithubAction)
 			}
+			// if string(actualService.Name) == string(schemas.Google) {
+			// 	actualGoogleAction := service.googleRepository.FindByWorkflowId(wf.Id)
+			// 	service.googleRepository.Delete(actualGoogleAction)
+			// }
 			err := service.repository.Delete(wf.Id)
 			if err != nil {
 				return err


### PR DESCRIPTION
This pull request includes a significant update to the `DeleteWorkflow` function in the `workflowService.go` file. The most important change is the addition of a switch statement to handle different service names, specifically adding support for GitHub actions.

Improvements to workflow deletion:

* [`backend/services/workflowService.go`](diffhunk://#diff-c16d658cf6677a7c0a3f1968cdb6304b27ccc24adc2557a91fd298abbfb8d28cL281-R295): Replaced the if condition with a switch statement to handle different service names, adding support for deleting GitHub actions in addition to Google actions.