### PR TITLE
Finishing the implementation of the microsoft service

### DIFF
--- a/backend/controllers/microsoftController.go
+++ b/backend/controllers/microsoftController.go
@@ -49,7 +49,7 @@ func (controller *microsoftController) RedirectionToMicrosoftService(ctx *gin.Co
 		return "", err
 	}
 	redirectUri := appAdressHost + appPort + path
-	authUrl := fmt.Sprintf("https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=%s&response_type=code&scope=openid profile Calendars.Read Calendars.ReadWrite Calendars.ReadWrite.Shared Calendars.Read.Shared Chat.Read https://graph.microsoft.com/User.Read&redirect_uri=%s&state=%s", clientId, redirectUri, state)
+	authUrl := fmt.Sprintf("https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=%s&response_type=code&scope=openid profile Calendars.Read Calendars.ReadWrite Calendars.ReadWrite.Shared Calendars.Read.Shared Chat.Read Mail.Send https://graph.microsoft.com/User.Read&redirect_uri=%s&state=%s", clientId, redirectUri, state)
 	return authUrl, nil
 }
 

--- a/backend/schemas/microsoftSchema.go
+++ b/backend/schemas/microsoftSchema.go
@@ -4,7 +4,13 @@ type MicrosoftAction string
 
 const (
 	MicrosoftOutlookEventsAction MicrosoftAction = "get_outlook_events"
-	MicrosoftTeamGroup MicrosoftAction = "modify_team_group"
+	MicrosoftTeamGroup           MicrosoftAction = "modify_team_group"
+)
+
+type MicrosoftReaction string
+
+const (
+	MicrosoftMailReaction MicrosoftReaction = "send_mail"
 )
 
 type MicrosoftUserInfo struct {
@@ -37,4 +43,28 @@ type MicrosoftOutlookEventsResponse struct {
 	Value []struct {
 		Subject string `json:"subject"`
 	} `json:"value"`
+}
+
+type MicrosoftSendMailBodyOptions struct {
+	ContentType string `json:"contentType"`
+	Content     string `json:"content"`
+}
+
+type MicrosoftSendMailAdressOptions struct {
+	Address string `json:"address"`
+}
+
+type MicrosoftSendMailRecipientsOptions struct {
+	EmailAdress MicrosoftSendMailAdressOptions `json:"emailAddress"`
+}
+
+type MicrosoftSendMailMainMessageOptions struct {
+	Subject      string                               `json:"subject"`
+	Body         MicrosoftSendMailBodyOptions         `json:"body"`
+	ToRecipients []MicrosoftSendMailRecipientsOptions `json:"toRecipients"`
+}
+
+type MicrosoftSendMailOptions struct {
+	Message         MicrosoftSendMailMainMessageOptions `json:"message"`
+	SaveToSentItems string                              `json:"saveToSentItems"`
 }

--- a/backend/services/githubService.go
+++ b/backend/services/githubService.go
@@ -337,9 +337,9 @@ func (service *githubService) LookAtPush(channel chan string, option string, wor
 			LastCommitDate: branch.Commit.Commit.Author.Date.Time,
 		})
 	}
-	actualRecords := service.githubRepository.FindByWorkflowId(workflow.Id)
 
 	if !(existingRecords.LastCommitDate).Equal(branch.Commit.Commit.Author.Date.Time) {
+		actualRecords := service.githubRepository.FindByWorkflowId(workflow.Id)
 		actualRecords.LastCommitDate = branch.Commit.Commit.Author.Date.Time
 		service.githubRepository.UpdatePushDate(actualRecords)
 		workflow.ReactionTrigger = true

--- a/backend/services/reactionService.go
+++ b/backend/services/reactionService.go
@@ -110,6 +110,28 @@ func NewReactionService(
 					LanguageCode: "string",
 				}),
 			},
+			{
+				Name:        string(schemas.MicrosoftMailReaction),
+				Description: "Send an email",
+				ServiceId:   serviceService.FindByName(schemas.Microsoft).Id,
+				Options: toolbox.MustMarshal(schemas.MicrosoftSendMailOptions{
+					Message: schemas.MicrosoftSendMailMainMessageOptions{
+						Subject: "string",
+						Body: schemas.MicrosoftSendMailBodyOptions{
+							ContentType: "string",
+							Content:     "string",
+						},
+						ToRecipients: []schemas.MicrosoftSendMailRecipientsOptions{
+							{
+								EmailAdress: schemas.MicrosoftSendMailAdressOptions{
+									Address: "string",
+								},
+							},
+						},
+					},
+					SaveToSentItems: "string",
+				}),
+			},
 		},
 		allReactions: []interface{}{serviceService},
 	}


### PR DESCRIPTION
This pull request introduces a new feature to send emails using the Microsoft service and includes several related changes across multiple files. The most important changes include adding new types for email options, updating the Microsoft service to handle email sending, and modifying existing functions to accommodate the new feature.

### New Feature: Send Emails via Microsoft Service

* [`backend/schemas/microsoftSchema.go`](diffhunk://#diff-98b7ef1dfee04b9baf527d380f43e3d444c3d577133bcb7db397948ce9d2ee1aR47-R70): Added new types for email options, including `MicrosoftSendMailBodyOptions`, `MicrosoftSendMailAdressOptions`, `MicrosoftSendMailRecipientsOptions`, `MicrosoftSendMailMainMessageOptions`, and `MicrosoftSendMailOptions`.

### Microsoft Service Updates

* [`backend/services/microsoftService.go`](diffhunk://#diff-a19d29d9d30022b55f13ec962e11fa27db408a67921929106cc60d182a3bbd5aR269-R329): Added the `SendMail` function to handle sending emails, including locking mechanisms and token handling.
* [`backend/services/microsoftService.go`](diffhunk://#diff-a19d29d9d30022b55f13ec962e11fa27db408a67921929106cc60d182a3bbd5aR132-R138): Updated the `FindReactionByName` function to return the `SendMail` function when the `MicrosoftMailReaction` is requested.

### Authorization URL Update

* [`backend/controllers/microsoftController.go`](diffhunk://#diff-d1304d2fef9170fce64dcb04cc861f5e7b2295f5d3f1e2d668befed167e74cecL52-R52): Updated the authorization URL to include the `Mail.Send` scope required for sending emails.

### Reaction Service Update

* [`backend/services/reactionService.go`](diffhunk://#diff-3864b95fedc28d870196e7d1fa0060cedac58a4c0ddde7d8c94c39804a092e99R113-R134): Added the new `MicrosoftMailReaction` to the list of available reactions, including its description and options.

### Code Refactoring

* [`backend/services/githubService.go`](diffhunk://#diff-ea08924425ea28ae01e98c3ee7955b64f9f48cb6ed8084b1297f14831e6149adL340-R342): Moved the `actualRecords` variable inside the conditional block to ensure it is only used when necessary.

This pull request close #64 