### PR TITLE
[UPD] creation of a google calendar event improvement

### DIFF
--- a/backend/schemas/googleSchema.go
+++ b/backend/schemas/googleSchema.go
@@ -47,6 +47,30 @@ type GoogleCalendarCorpusOptionsTime struct {
 	TimeZone string `json:"timeZone"`
 }
 
+type GoogleCalendarCorpusOptionsTimeStartSchema struct {
+	StartDateTime string `json:"startDateTime"`
+	StartTimeZone string `json:"startTimeZone"`
+}
+
+type GoogleCalendarCorpusOptionsTimeEndSchema struct {
+	EndDateTime string `json:"endDateTime"`
+	EndTimeZone string `json:"endTimeZone"`
+}
+
+type GoogleCalendarCorpusOptionsSchema struct {
+	Summary     string                                     `json:"summary"`
+	Description string                                     `json:"description"`
+	Location    string                                     `json:"location"`
+	Start       GoogleCalendarCorpusOptionsTimeStartSchema `json:"start"`
+	End         GoogleCalendarCorpusOptionsTimeEndSchema   `json:"end"`
+	Attendees   GoogleCalendarCorpusOptionsAttendees       `json:"attendees"`
+}
+
+type GoogleCalendarOptionsSchema struct {
+	CalendarId     string                            `json:"calendar_id"`
+	CalendarCorpus GoogleCalendarCorpusOptionsSchema `json:"calendar_corpus"`
+}
+
 type GoogleCalendarCorpusOptionsAttendees struct {
 	Email string `json:"email"`
 }

--- a/backend/services/reactionService.go
+++ b/backend/services/reactionService.go
@@ -54,19 +54,19 @@ func NewReactionService(
 				Name:        string(schemas.GoogleCreateEventReaction),
 				Description: "Create an event in Google Calendar",
 				ServiceId:   serviceService.FindByName(schemas.Google).Id,
-				Options: toolbox.RealObject(schemas.GoogleCalendarOptions{
+				Options: toolbox.RealObject(schemas.GoogleCalendarOptionsSchema{
 					CalendarId: "your address email",
-					CalendarCorpus: schemas.GoogleCalendarCorpusOptions{
+					CalendarCorpus: schemas.GoogleCalendarCorpusOptionsSchema{
 						Summary:     "Réunion",
 						Description: "on va parler de l'avenir",
 						Location:    "Osaka",
-						Start: schemas.GoogleCalendarCorpusOptionsTime{
-							DateTime: "2025-01-15T10:00:00.0000000",
-							TimeZone: "Europe/Paris",
+						Start: schemas.GoogleCalendarCorpusOptionsTimeStartSchema{
+							StartDateTime: "2025-01-15T10:00:00.0000000",
+							StartTimeZone: "Europe/Paris",
 						},
-						End: schemas.GoogleCalendarCorpusOptionsTime{
-							DateTime: "2025-01-15T10:00:00.0000000",
-							TimeZone: "Europe/Paris",
+						End: schemas.GoogleCalendarCorpusOptionsTimeEndSchema{
+							EndDateTime: "2025-01-15T10:00:00.0000000",
+							EndTimeZone: "Europe/Paris",
 						},
 						Attendees: schemas.GoogleCalendarCorpusOptionsAttendees{
 							Email: "my.email@gmail.com",


### PR DESCRIPTION
This pull request introduces several changes to the Google Calendar event creation functionality in the backend. The changes primarily involve updating the schema definitions and modifying the service logic to accommodate these new schemas.

Schema updates:

* Added new types `GoogleCalendarCorpusOptionsTimeStartSchema`, `GoogleCalendarCorpusOptionsTimeEndSchema`, `GoogleCalendarCorpusOptionsSchema`, and `GoogleCalendarOptionsSchema` to `backend/schemas/googleSchema.go`. These new types provide a more detailed structure for calendar event options, including separate start and end time schemas.

Service logic updates:

* Updated the `CreateEventReaction` function in `backend/services/googleService.go` to iterate over all tokens and validate the workflow trigger status before proceeding with event creation. This ensures that reactions are only triggered when appropriate.
* Modified the `CreateEventReaction` function to use the new `GoogleCalendarOptionsSchema` type and convert it to the existing `GoogleCalendarOptions` type before making API requests. This change ensures compatibility with the updated schema definitions. [[1]](diffhunk://#diff-1a6b5aaa731716dc69ab87cc537aba0432e2aa7d000af66fc613e35b0d7aca39L233-R272) [[2]](diffhunk://#diff-1a6b5aaa731716dc69ab87cc537aba0432e2aa7d000af66fc613e35b0d7aca39L259-R300)
* Updated the `NewReactionService` function in `backend/services/reactionService.go` to use the new schema types for initializing reaction options. This change ensures that the correct schema structure is used when creating new reactions.