### PR TITLE
[UPD] schemas && format a file

### DIFF
--- a/backend/api/workflowApi.go
+++ b/backend/api/workflowApi.go
@@ -56,7 +56,6 @@ func (api *WorkflowApi) GetMostRecentReaction(ctx *gin.Context) {
 	}
 }
 
-
 func (api *WorkflowApi) DeleteWorkflow(ctx *gin.Context) {
 	err := api.workflowController.DeleteWorkflow(ctx)
 	if err != nil && err.Error() == "no authorization header found" {

--- a/backend/schemas/actionsSchema.go
+++ b/backend/schemas/actionsSchema.go
@@ -24,7 +24,7 @@ type Action struct {
 	Id          uint64          `json:"id,omitempty" gorm:"primary_key;auto_increment"`
 	Name        string          `json:"name" gorm:"type:varchar(100)"`
 	ServiceId   uint64          `json:"-"`
-	Service     Service         `json:"service,omitempty" gorm:"foreignkey:ServiceId;references:Id"`
+	Service     Service         `json:"service,omitempty" gorm:"foreignkey:ServiceId;references:Id;constraint:OnDelete:CASCADE;"`
 	Description string          `json:"description" gorm:"type:varchar(100)"`
 	CreatedAt   time.Time       `json:"created_at" gorm:"default:CURRENT_TIMESTAMP"`
 	UpdatedAt   time.Time       `json:"updated_at" gorm:"default:CURRENT_TIMESTAMP"`

--- a/backend/schemas/githubSchema.go
+++ b/backend/schemas/githubSchema.go
@@ -40,7 +40,7 @@ type GithubListCommentsResponse struct {
 
 type GithubPullRequestOptionsTable struct {
 	Id     uint64 `json:"id,omitempty" gorm:"primary_key;auto_increment"`
-	User   User   `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
+	User   User   `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id;constraint:OnDelete:CASCADE;"`
 	UserId uint64 `json:"-"`
 	Repo   string `json:"repo"`
 	Owner  string `json:"owner"`
@@ -65,9 +65,9 @@ type GithubPushOnRepoOptions struct {
 
 type GithubPushOnRepoOptionsTable struct {
 	Id             uint64    `json:"id,omitempty" gorm:"primary_key;auto_increment"`
-	User           User      `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
+	User           User      `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id;constraint:OnDelete:CASCADE;"`
 	UserId         uint64    `json:"-"`
-	Workflow       Workflow  `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id"`
+	Workflow       Workflow  `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id;constraint:OnDelete:CASCADE;"`
 	WorkflowId     uint64    `json:"-"`
 	LastCommitDate time.Time `gorm:"default:CURRENT_TIMESTAMP" json:"last_commit_date"`
 }

--- a/backend/schemas/googleSchema.go
+++ b/backend/schemas/googleSchema.go
@@ -31,9 +31,9 @@ type GoogleActionOptions struct {
 
 type GoogleActionResponse struct {
 	Id                 uint64   `json:"id,omitempty" gorm:"primary_key;auto_increment"`
-	User               User     `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
+	User               User     `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id;constraint:OnDelete:CASCADE;"`
 	UserId             uint64   `json:"-"`
-	Worflow            Workflow `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id"`
+	Worflow            Workflow `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id;constraint:OnDelete:CASCADE;"`
 	WorkflowId         uint64   `json:"-"`
 	ResultSizeEstimate int      `json:"result_size_estimate"`
 }

--- a/backend/schemas/passwordRecoverySchema.go
+++ b/backend/schemas/passwordRecoverySchema.go
@@ -2,7 +2,7 @@ package schemas
 
 type PasswordRecovery struct {
 	Id          uint64 `json:"id,omitempty" gorm:"primary_key;auto_increment"`
-	UserId      User   `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
+	UserId      User   `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id;constraint:OnDelete:CASCADE;"`
 	Code        string `json:"code" gorm:"type:varchar(100)"`
 	IsValidated bool   `json:"is_validated" gorm:"type:boolean"`
 }

--- a/backend/schemas/reactionsSchema.go
+++ b/backend/schemas/reactionsSchema.go
@@ -15,7 +15,7 @@ type ReactionJson struct {
 type ReactionResponseData struct {
 	Id          uint64          `json:"id,omitempty" gorm:"primary_key;auto_increment"`
 	WorkflowId  uint64          `json:"workflow_id"`
-	Workflow    Workflow        `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id"`
+	Workflow    Workflow        `json:"workflow,omitempty" gorm:"foreignkey:WorkflowId;references:Id;constraint:OnDelete:CASCADE;"`
 	ApiResponse json.RawMessage `gorm:"type:jsonb" json:"apiResponse"`
 	CreatedAt   time.Time       `json:"created_at" gorm:"default:CURRENT_TIMESTAMP"`
 }
@@ -23,7 +23,7 @@ type ReactionResponseData struct {
 type Reaction struct {
 	Id          uint64          `json:"id,omitempty" gorm:"primary_key;auto_increment"`
 	ServiceId   uint64          `json:"-"`
-	Service     Service         `json:"service,omitempty" gorm:"foreignkey:ServiceId;references:Id"`
+	Service     Service         `json:"service,omitempty" gorm:"foreignkey:ServiceId;references:Id;constraint:OnDelete:CASCADE;"`
 	Name        string          `json:"name" gorm:"type:varchar(100)"`
 	Description string          `json:"description" gorm:"type:varchar(100)"`
 	CreatedAt   time.Time       `json:"created_at" gorm:"default:CURRENT_TIMESTAMP"`

--- a/backend/schemas/relationsSchema.go
+++ b/backend/schemas/relationsSchema.go
@@ -1,7 +1,0 @@
-package schemas
-
-type UserServiceLink struct {
-	Id        uint64  `json:"id,omitempty" gorm:"primary_key;auto_increment"`
-	UserId    User    `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
-	ServiceId Service `json:"service,omitempty" gorm:"foreignkey:ServiceId;references:Id"`
-}

--- a/backend/schemas/serviceTokenSchema.go
+++ b/backend/schemas/serviceTokenSchema.go
@@ -5,13 +5,13 @@ import "time"
 type ServiceToken struct {
 	Id           uint64    `gorm:"primaryKey;autoIncrement"           json:"id,omitempty"`
 	UserId       uint64    `                                          json:"-"`
-	User         User      `gorm:"foreignKey:UserId;references:Id"    json:"user_id"`
+	User         User      `gorm:"foreignKey:UserId;references:Id;constraint:OnDelete:CASCADE;"    json:"user_id"`
 	ServiceId    uint64    `                                          json:"-"`
-	Service      Service   `gorm:"foreignKey:ServiceId;references:Id" json:"service_id"`
+	Service      Service   `gorm:"foreignKey:ServiceId;references:Id;constraint:OnDelete:CASCADE;" json:"service_id"`
 	Token        string    `                                          json:"token"`
 	RefreshToken string    `                                          json:"refresh_token"`
 	ExpireAt     time.Time `                                          json:"expireAt"`
 	CreatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP"          json:"createdAt"`
 	UpdateAt     time.Time `gorm:"default:CURRENT_TIMESTAMP"          json:"updateAt"`
-	Users        []User    `gorm:"many2many:user_service_tokens;"`
+	Users        []User    `gorm:"many2many:user_service_tokens;constraint:OnDelete:CASCADE;"`
 }

--- a/backend/schemas/userSchema.go
+++ b/backend/schemas/userSchema.go
@@ -1,7 +1,7 @@
 package schemas
 
 type User struct {
-	Id       uint64         `json:"id,omitempty" gorm:"primary_key;auto_increment"`
+	Id       uint64         `json:"id,omitempty" gorm:"primary_key;auto_increment;"`
 	Name     string         `json:"name" gorm:"type:varchar(100)"`
 	LastName string         `json:"lastname" gorm:"type:varchar(100)"`
 	Username string         `json:"username" gorm:"type:varchar(100);unique"`
@@ -9,5 +9,5 @@ type User struct {
 	Password *string        `json:"password" gorm:"type:varchar(100)"`
 	Image    string         `json:"image" gorm:"type:BYTEA"`
 	IsAdmin  bool           `json:"is_admin" gorm:"type:boolean"`
-	Services []ServiceToken `gorm:"many2many:user_service_tokens;"`
+	Services []ServiceToken `gorm:"many2many:user_service_tokens;constraint:OnDelete:CASCADE;"`
 }

--- a/backend/schemas/workflowsSchema.go
+++ b/backend/schemas/workflowsSchema.go
@@ -33,12 +33,12 @@ type WorkflowJson struct {
 type Workflow struct {
 	Id              uint64          `json:"id,omitempty" gorm:"primary_key;auto_increment"`
 	UserId          uint64          `json:"-"`
-	User            User            `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id"`
+	User            User            `json:"user,omitempty" gorm:"foreignkey:UserId;references:Id;constraint:OnDelete:CASCADE;"`
 	ActionId        uint64          `json:"-"`
-	Action          Action          `json:"action,omitempty" gorm:"foreignkey:ActionId;references:Id"`
+	Action          Action          `json:"action,omitempty" gorm:"foreignkey:ActionId;references:Id;constraint:OnDelete:CASCADE;";`
 	ActionOptions   json.RawMessage `gorm:"type:jsonb" json:"action_options"`
 	ReactionId      uint64          `json:"-"`
-	Reaction        Reaction        `json:"reaction,omitempty" gorm:"foreignkey:ReactionId;references:Id"`
+	Reaction        Reaction        `json:"reaction,omitempty" gorm:"foreignkey:ReactionId;references:Id;constraint:OnDelete:CASCADE;"`
 	ReactionOptions json.RawMessage `gorm:"type:jsonb" json:"reaction_options"`
 	CreatedAt       time.Time       `json:"created_at" gorm:"default:CURRENT_TIMESTAMP"`
 	UpdatedAt       time.Time       `json:"updated_at" gorm:"default:CURRENT_TIMESTAMP"`


### PR DESCRIPTION
This pull request includes several changes to the backend schemas to enforce cascading deletes. Additionally, there is a minor cleanup in the `workflowApi.go` file. The most important changes include adding `OnDelete:CASCADE` constraints to various foreign key relationships and removing an unused schema.

Changes to enforce cascading deletes:

* [`backend/schemas/actionsSchema.go`](diffhunk://#diff-77635bb9b280c3ca991c4653de6f28f09acaba809e4dde0eab2e4037212c4e28L27-R27): Added `constraint:OnDelete:CASCADE;` to the `Service` field in the `Action` struct.
* [`backend/schemas/githubSchema.go`](diffhunk://#diff-8bfd9d753fff2fc6828e54fd84baae0eb55407ca8fae19f421391c33dd296e73L43-R43): Added `constraint:OnDelete:CASCADE;` to the `User` field in the `GithubPullRequestOptionsTable` struct, and to both the `User` and `Workflow` fields in the `GithubPushOnRepoOptionsTable` struct. [[1]](diffhunk://#diff-8bfd9d753fff2fc6828e54fd84baae0eb55407ca8fae19f421391c33dd296e73L43-R43) [[2]](diffhunk://#diff-8bfd9d753fff2fc6828e54fd84baae0eb55407ca8fae19f421391c33dd296e73L68-R70)
* [`backend/schemas/googleSchema.go`](diffhunk://#diff-6748e5a0efda38b9f92b6d7eb4c26443e0065f43c5b1cd95aa221e9f3e3e35a5L34-R36): Added `constraint:OnDelete:CASCADE;` to the `User` and `Workflow` fields in the `GoogleActionResponse` struct.
* [`backend/schemas/reactionsSchema.go`](diffhunk://#diff-b35327e6b9b3a8cc1cf1184abb5cfd11fd551cb655f5ce5f9fb894074614a9f2L18-R26): Added `constraint:OnDelete:CASCADE;` to the `Workflow` and `Service` fields in the `ReactionResponseData` and `Reaction` structs respectively.
* [`backend/schemas/passwordRecoverySchema.go`](diffhunk://#diff-8a393d3868e3ea511bba6429bc45bcadf6a64cf64f16552a10fbfde67969ad3eL5-R5): Added `constraint:OnDelete:CASCADE;` to the `UserId` field in the `PasswordRecovery` struct.
* [`backend/schemas/serviceTokenSchema.go`](diffhunk://#diff-3e10d7bd07f622150e2cf4e86ac2fe9e1ddb7ac12ee8f70eedcaf3a6c969e664L8-R16): Added `constraint:OnDelete:CASCADE;` to the `User` and `Service` fields in the `ServiceToken` struct.
* [`backend/schemas/userSchema.go`](diffhunk://#diff-b4569950eb1c00af40935466773f6e391bc34352190c60dba89e7926cc12edecL4-R12): Added `constraint:OnDelete:CASCADE;` to the `Services` field in the `User` struct.
* [`backend/schemas/workflowsSchema.go`](diffhunk://#diff-baa93a2e071d5562316a8267e401a857cb4b12458d4831928f6a042986de8e9dL36-R41): Added `constraint:OnDelete:CASCADE;` to the `User`, `Action`, and `Reaction` fields in the `Workflow` struct.

Code cleanup:

* [`backend/api/workflowApi.go`](diffhunk://#diff-bc0f474aa53f61fe78e9b56582932cc606703f2710194c8ed6f9e8dc2910c496L59): Removed an unnecessary blank line.

Removal of unused schema:

* [`backend/schemas/relationsSchema.go`](diffhunk://#diff-4af1ab66da0e31654660effbe16cca821a62a25c612b461cc7fdeb052339fca0L1-L7): Deleted the `UserServiceLink` struct.