### PR TITLE
[UPD] microsoft schema for the frontend

### DIFF
--- a/backend/schemas/microsoftSchema.go
+++ b/backend/schemas/microsoftSchema.go
@@ -69,6 +69,17 @@ type MicrosoftSendMailOptions struct {
 	SaveToSentItems string                              `json:"saveToSentItems"`
 }
 
+type MicrosoftSendMailMainMessageOptionsSchema struct {
+	Subject string                       `json:"subject"`
+	Body    MicrosoftSendMailBodyOptions `json:"body"`
+	Address string                       `json:"address"`
+}
+
+type MicrosoftSendMailOptionsSchema struct {
+	Message         MicrosoftSendMailMainMessageOptionsSchema `json:"message"`
+	SaveToSentItems string                                    `json:"saveToSentItems"`
+}
+
 // message: {
 // 	body: {
 // 	  content: "This email is to confirm our trip to Chicoutimi",

--- a/backend/services/microsoftService.go
+++ b/backend/services/microsoftService.go
@@ -285,15 +285,32 @@ func (service *microsoftService) SendMail(channel chan string, workflowId uint64
 
 	workflow := service.workflowRepository.FindById(workflowId)
 
-	options := schemas.MicrosoftSendMailOptions{}
+	options := schemas.MicrosoftSendMailOptionsSchema{}
 	err := json.Unmarshal([]byte(reactionOption), &options)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
+	trueOptions := schemas.MicrosoftSendMailOptions{
+		Message: schemas.MicrosoftSendMailMainMessageOptions{
+			Subject: options.Message.Subject,
+			Body: schemas.MicrosoftSendMailBodyOptions{
+				ContentType: options.Message.Body.ContentType,
+				Content:     options.Message.Body.Content,
+			},
+			ToRecipients: []schemas.MicrosoftSendMailRecipientsOptions{
+				{
+					EmailAdress: schemas.MicrosoftSendMailAdressOptions{
+						Address: options.Message.Address,
+					},
+				},
+			},
+		},
+		SaveToSentItems: options.SaveToSentItems,
+	}
 	url := "https://graph.microsoft.com/v1.0/me/sendMail"
 
-	jsonData, err := json.Marshal(options)
+	jsonData, err := json.Marshal(trueOptions)
 	if err != nil {
 		return
 	}

--- a/backend/services/reactionService.go
+++ b/backend/services/reactionService.go
@@ -114,20 +114,14 @@ func NewReactionService(
 				Name:        string(schemas.MicrosoftMailReaction),
 				Description: "Send an email",
 				ServiceId:   serviceService.FindByName(schemas.Microsoft).Id,
-				Options: toolbox.RealObject(schemas.MicrosoftSendMailOptions{
-					Message: schemas.MicrosoftSendMailMainMessageOptions{
+				Options: toolbox.RealObject(schemas.MicrosoftSendMailOptionsSchema{
+					Message: schemas.MicrosoftSendMailMainMessageOptionsSchema{
 						Subject: "We are going to Chicoutimi ?",
 						Body: schemas.MicrosoftSendMailBodyOptions{
 							ContentType: "Text",
 							Content:     "This email is to confirm our trip to Chicoutimi",
 						},
-						ToRecipients: []schemas.MicrosoftSendMailRecipientsOptions{
-							{
-								EmailAdress: schemas.MicrosoftSendMailAdressOptions{
-									Address: "other.email@gmail.com",
-								},
-							},
-						},
+						Address: "my.email@gmail.com",
 					},
 					SaveToSentItems: "true / false",
 				}),


### PR DESCRIPTION
This pull request includes changes to the `backend` package to enhance the email sending functionality by introducing new schema types and updating the relevant service methods. The most important changes include the addition of new schema types for email options, updating the `SendMail` method to use the new schema, and modifying the `NewReactionService` method to reflect these changes.

Schema changes:
* [`backend/schemas/microsoftSchema.go`](diffhunk://#diff-98b7ef1dfee04b9baf527d380f43e3d444c3d577133bcb7db397948ce9d2ee1aR72-R82): Added `MicrosoftSendMailMainMessageOptionsSchema` and `MicrosoftSendMailOptionsSchema` types to structure the email options more clearly.

Service method updates:
* [`backend/services/microsoftService.go`](diffhunk://#diff-a19d29d9d30022b55f13ec962e11fa27db408a67921929106cc60d182a3bbd5aL288-R313): Updated the `SendMail` method to use the new `MicrosoftSendMailOptionsSchema` type and convert it to the existing `MicrosoftSendMailOptions` type before sending the email.
* [`backend/services/reactionService.go`](diffhunk://#diff-3864b95fedc28d870196e7d1fa0060cedac58a4c0ddde7d8c94c39804a092e99L117-R124): Modified the `NewReactionService` method to use the new `MicrosoftSendMailOptionsSchema` type for initializing email options.