### PR TITLE
[ADD] adding create_playlist reaction

### DIFF
--- a/backend/schemas/spotifySchema.go
+++ b/backend/schemas/spotifySchema.go
@@ -10,6 +10,7 @@ type SpotifyReaction string
 
 const (
 	SpotifyAddTrackReaction SpotifyReaction = "add_track_reaction"
+	SpotifyCreatePlaylist   SpotifyReaction = "create_playlist"
 )
 
 type SpotifyResponseToken struct {
@@ -46,4 +47,11 @@ type SpotifyTracksInfos struct {
 
 type SpotifyPlaylistInfos struct {
 	Tracks SpotifyTracksInfos `json:"tracks"`
+}
+
+type SpotifyPlaylistOptions struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Public        bool `json:"public"`
+	Collaborative bool `json:"collaborative"`
 }

--- a/backend/services/reactionService.go
+++ b/backend/services/reactionService.go
@@ -51,6 +51,17 @@ func NewReactionService(
 				}),
 			},
 			{
+				Name:        string(schemas.SpotifyCreatePlaylist),
+				Description: "Create a new Playlist",
+				ServiceId:   serviceService.FindByName(schemas.Spotify).Id,
+				Options: toolbox.RealObject(schemas.SpotifyPlaylistOptions{
+					Name: "Playlist Hardstyle",
+					Description: "BOOM BOOM BOOM",
+					Public: true,
+					Collaborative: false,
+				}),
+			},
+			{
 				Name:        string(schemas.GoogleCreateEventReaction),
 				Description: "Create an event in Google Calendar",
 				ServiceId:   serviceService.FindByName(schemas.Google).Id,

--- a/backend/services/spotifyService.go
+++ b/backend/services/spotifyService.go
@@ -1,9 +1,11 @@
 package services
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -107,6 +109,8 @@ func (service *spotifyService) FindReactionByName(name string) func(channel chan
 	switch name {
 	case string(schemas.SpotifyAddTrackReaction):
 		return service.AddTrackReaction
+	case string(schemas.SpotifyCreatePlaylist):
+		return service.CreatePlaylist
 	default:
 		return nil
 	}
@@ -158,26 +162,56 @@ func (service *spotifyService) AddTrackAction(channel chan string, workflowId ui
 		return
 	}
 
+	defer response.Body.Close()
 	result := schemas.SpotifyPlaylistInfos{}
-	err = json.NewDecoder(response.Body).Decode(&result)
+	bodyBytes, _ := io.ReadAll(response.Body)
+	err = json.Unmarshal(bodyBytes, &result)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	defer response.Body.Close()
-	if options.IsOld {
-		options.NbSongs = result.Tracks.Total
-		if options.NbSongs < result.Tracks.Total {
-			workflow.ReactionTrigger = true
+
+	existingRecords := map[string]interface{}{}
+	if string(workflow.Utils) != "" {
+		err = json.Unmarshal([]byte(workflow.Utils), &existingRecords)
+		if err != nil {
+			fmt.Println("Error unmarshaliing existingRecords: ", err)
+			return
 		}
-		workflow.ActionOptions = toolbox.RealObject(options)
-		service.workflowRepository.Update(workflow)
-	} else {
-		options.NbSongs = result.Tracks.Total
-		options.IsOld = true
-		workflow.ActionOptions = toolbox.RealObject(options)
+	}
+
+	if existingRecords["Tracks"] == nil {
+		existingRecords["Tracks"] = 0
+		jsonData, err := json.Marshal(existingRecords)
+		if err != nil {
+			fmt.Println("Error marshalling existingRecords:", err)
+			return
+		}
+		workflow.Utils = jsonData
 		service.workflowRepository.Update(workflow)
 	}
+
+	var nbTracks uint64
+	switch v := existingRecords["Tracks"].(type) {
+	case float64:
+		nbTracks = uint64(v)
+	case uint64:
+		nbTracks = v
+	default:
+		fmt.Println("Error asserting nbTracks to int or float64")
+		return
+	}
+	existingRecords["Tracks"] = result.Tracks.Total
+	jsonData, err := json.Marshal(existingRecords)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	workflow.Utils = jsonData
+	if result.Tracks.Total > nbTracks {
+		workflow.ReactionTrigger = true
+	}
+	service.workflowRepository.Update(workflow)
 	channel <- "Action workflow done"
 }
 
@@ -238,6 +272,50 @@ func (service *spotifyService) AddTrackReaction(channel chan string, workflowId 
 		return
 	}
 
+	workflow.ReactionTrigger = false
+	service.workflowRepository.UpdateReactionTrigger(workflow)
+}
+
+func (service *spotifyService) CreatePlaylist(channel chan string, workflowId uint64, accessToken []schemas.ServiceToken, reactionOption json.RawMessage) {
+	service.mutex.Lock()
+	defer service.mutex.Unlock()
+	workflow, err := service.workflowRepository.FindByIds(workflowId)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	options := schemas.SpotifyPlaylistOptions{}
+	err = json.Unmarshal([]byte(reactionOption), &options)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+    optionsJSON, err := json.Marshal(options)
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+	request, err := http.NewRequest("POST", "https://api.spotify.com/v1/me/playlists", bytes.NewBuffer(optionsJSON))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	client := &http.Client{}
+	searchedService := service.serviceRepository.FindByName(schemas.Spotify)
+
+	for _, token := range accessToken {
+		if token.ServiceId == searchedService.Id {
+			request.Header.Set("Authorization", "Bearer "+token.Token)
+		}
+	}
+	_, err = client.Do(request)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	workflow.ReactionTrigger = false
 	service.workflowRepository.UpdateReactionTrigger(workflow)
 }


### PR DESCRIPTION
This pull request introduces a new feature to create Spotify playlists and includes several changes across multiple files to support this functionality. The most significant changes include adding a new Spotify reaction type, defining the necessary options for playlist creation, updating the reaction service to handle the new reaction, and implementing the logic for creating a playlist in the Spotify service.

### New Spotify Playlist Creation Feature:

* [`backend/schemas/spotifySchema.go`](diffhunk://#diff-66c190c8c2b99112d41fcd49559da7560dcc7078391f4110fbc8ad35f188e226R13): Added `SpotifyCreatePlaylist` reaction type and defined `SpotifyPlaylistOptions` struct to hold playlist creation parameters. [[1]](diffhunk://#diff-66c190c8c2b99112d41fcd49559da7560dcc7078391f4110fbc8ad35f188e226R13) [[2]](diffhunk://#diff-66c190c8c2b99112d41fcd49559da7560dcc7078391f4110fbc8ad35f188e226R51-R57)

* [`backend/services/reactionService.go`](diffhunk://#diff-3864b95fedc28d870196e7d1fa0060cedac58a4c0ddde7d8c94c39804a092e99R53-R63): Updated `NewReactionService` to include the new `SpotifyCreatePlaylist` reaction with the necessary options.

* `backend/services/spotifyService.go`: 
  - Added necessary imports for handling HTTP requests and JSON encoding/decoding.
  - Updated `FindReactionByName` to return the `CreatePlaylist` function for the new reaction.
  - Refactored `AddTrackAction` to handle response body closing and JSON unmarshalling more robustly.
  - Implemented `CreatePlaylist` function to handle the creation of a new playlist on Spotify.