### PR TITLE
[FIX] modify_group now takes an Topic instead of an ID

### DIFF
--- a/backend/schemas/microsoftSchema.go
+++ b/backend/schemas/microsoftSchema.go
@@ -35,7 +35,7 @@ type MicrosoftTeamsGroupOptionsInfos struct {
 
 type MicrosoftTeamsChatResponse struct {
 	IsOld               bool   `json:"is_old"`
-	Id                  string `json:"id"`
+	Name                  string `json:"name"`
 	LastUpdatedDateTime string `json:"lastUpdatedDateTime"`
 }
 
@@ -78,6 +78,16 @@ type MicrosoftSendMailMainMessageOptionsSchema struct {
 type MicrosoftSendMailOptionsSchema struct {
 	Message         MicrosoftSendMailMainMessageOptionsSchema `json:"message"`
 	SaveToSentItems string                                    `json:"saveToSentItems"`
+}
+
+type MicrosoftTeams struct {
+	Id string `json:"id"`
+	Topic string `json:"topic"`
+	ChatType string `json:"chatType"`
+}
+
+type MicrosoftTeamsResponse struct {
+	Value []MicrosoftTeams `json:"value"`
 }
 
 // message: {

--- a/backend/services/spotifyService.go
+++ b/backend/services/spotifyService.go
@@ -284,6 +284,9 @@ func (service *spotifyService) CreatePlaylist(channel chan string, workflowId ui
 		fmt.Println(err)
 		return
 	}
+	if !workflow.ReactionTrigger {
+		return
+	}
 
 	options := schemas.SpotifyPlaylistOptions{}
 	err = json.Unmarshal([]byte(reactionOption), &options)


### PR DESCRIPTION
This pull request includes several changes to the `backend/schemas/microsoftSchema.go` and `backend/services/microsoftService.go` files to enhance the functionality related to Microsoft Teams and mail options. Additionally, there is a small update in the `backend/services/spotifyService.go` file to add a condition for creating a playlist.

### Microsoft Teams and Mail Options Enhancements:

* [`backend/schemas/microsoftSchema.go`](diffhunk://#diff-98b7ef1dfee04b9baf527d380f43e3d444c3d577133bcb7db397948ce9d2ee1aL38-R38): Added new structs `MicrosoftTeams` and `MicrosoftTeamsResponse` to handle Microsoft Teams data. Modified `MicrosoftTeamsChatResponse` by replacing the `Id` field with a `Name` field. [[1]](diffhunk://#diff-98b7ef1dfee04b9baf527d380f43e3d444c3d577133bcb7db397948ce9d2ee1aL38-R38) [[2]](diffhunk://#diff-98b7ef1dfee04b9baf527d380f43e3d444c3d577133bcb7db397948ce9d2ee1aR83-R92)

* [`backend/services/microsoftService.go`](diffhunk://#diff-a19d29d9d30022b55f13ec962e11fa27db408a67921929106cc60d182a3bbd5aR151-R230): Updated `ModifyTeamGroup` function to fetch and decode Microsoft Teams data, search for a specific team by name, and update the workflow's action options accordingly.

### Spotify Service Update:

* [`backend/services/spotifyService.go`](diffhunk://#diff-90ecb67feb7a263870a970113f3a373da359e5c4e93741cd8c9c778314a597c8R287-R289): Added a condition to check if `workflow.ReactionTrigger` is true before proceeding with creating a playlist in the `CreatePlaylist` function.