### PR TITLE
Merge on dev

### DIFF
--- a/backend/schemas/microsoftSchema.go
+++ b/backend/schemas/microsoftSchema.go
@@ -35,7 +35,7 @@ type MicrosoftTeamsGroupOptionsInfos struct {
 
 type MicrosoftTeamsChatResponse struct {
 	IsOld               bool   `json:"is_old"`
-	Id                  string `json:"id"`
+	Name                  string `json:"name"`
 	LastUpdatedDateTime string `json:"lastUpdatedDateTime"`
 }
 
@@ -78,6 +78,16 @@ type MicrosoftSendMailMainMessageOptionsSchema struct {
 type MicrosoftSendMailOptionsSchema struct {
 	Message         MicrosoftSendMailMainMessageOptionsSchema `json:"message"`
 	SaveToSentItems string                                    `json:"saveToSentItems"`
+}
+
+type MicrosoftTeams struct {
+	Id string `json:"id"`
+	Topic string `json:"topic"`
+	ChatType string `json:"chatType"`
+}
+
+type MicrosoftTeamsResponse struct {
+	Value []MicrosoftTeams `json:"value"`
 }
 
 // message: {

--- a/backend/services/spotifyService.go
+++ b/backend/services/spotifyService.go
@@ -285,6 +285,9 @@ func (service *spotifyService) CreatePlaylist(channel chan string, workflowId ui
 		fmt.Println(err)
 		return
 	}
+	if !workflow.ReactionTrigger {
+		return
+	}
 
 	options := schemas.SpotifyPlaylistOptionsSchema{}
 	err = json.Unmarshal([]byte(reactionOption), &options)


### PR DESCRIPTION
This pull request includes several changes to the `backend/schemas/microsoftSchema.go` and `backend/services/microsoftService.go` files to enhance the Microsoft Teams integration, as well as a small update to the Spotify service.

### Microsoft Teams Integration Enhancements:

* `backend/schemas/microsoftSchema.go`: 
  - Changed the `MicrosoftTeamsChatResponse` struct to replace the `Id` field with a `Name` field.
  - Added new structs `MicrosoftTeams` and `MicrosoftTeamsResponse` to handle Teams data.

* `backend/services/microsoftService.go`: 
  - Modified the `ModifyTeamGroup` function to include logic for fetching and decoding Microsoft Teams data, and to use the `Name` field for identifying teams.

### Spotify Service Update:

* `backend/services/spotifyService.go`: 
  - Updated the `CreatePlaylist` function to return early if the `workflow.ReactionTrigger` is not set, preventing unnecessary operations.